### PR TITLE
Remove creation of proxy outpost

### DIFF
--- a/terraform/modules/proxy_auth/main.tf
+++ b/terraform/modules/proxy_auth/main.tf
@@ -7,9 +7,14 @@ terraform {
   }
 }
 
+/*
+
+No easy way to do this, have to manually assign applications to the outpost.  
+See: https://github.com/goauthentik/terraform-provider-authentik/issues/310 
 resource "authentik_outpost" "outpost" {
   name = "tf_${var.name}_outpost"
   protocol_providers = [
     authentik_provider_proxy.name.id
   ]
 }
+*/


### PR DESCRIPTION
We'll just have to manually assign the applications to the default proxy outpost due to the issue noted here: https://github.com/DCCoder90/home-net/issues/12