### PR TITLE
Fixed 301 redirect loop

### DIFF
--- a/terraform/modules/dns/nginxproxy.tf
+++ b/terraform/modules/dns/nginxproxy.tf
@@ -29,7 +29,7 @@ resource "nginxproxymanager_proxy_host" "host" {
   access_list_id = var.access_list_id
 
   certificate_id  = nginxproxymanager_certificate_letsencrypt.certificate.id
-  ssl_forced      = true
+  ssl_forced      = false
   hsts_enabled    = false
   hsts_subdomains = false
   http2_support   = true


### PR DESCRIPTION
With NGINX set to `ssl_forced      = true`, when accessing the site via cloudflare it issues a 301 response trying to force the user into using SSL whether SSL is being used or not.  This may be due to my own misunderstanding how what the "Force SSL" setting is.