### PR TITLE
Remove readarr

### DIFF
--- a/config/stacks/arr.yaml
+++ b/config/stacks/arr.yaml
@@ -87,21 +87,3 @@
         image_name: "linuxserver/lidarr:2.13.0-develop"
         mounts:
           - "/mnt/user/Arr/lidarr-data:/config"
-      readarr:
-        dns:
-          enabled: true
-          domain_name: "readarr.dcapi.app"
-        network:
-          internal: true
-          service_port: 8787
-          networks:
-            - name: "br1"
-              ip_address: "192.168.5.26"
-        auth:
-          enabled: true
-          proxy: true
-          group: "Arr"
-        service_name: "readarr"
-        image_name: "linuxserver/readarr:0.4.17-develop"
-        mounts:
-          - "/mnt/user/Arr/readarr-data:/config"


### PR DESCRIPTION
Readarr has been retired per https://github.com/Readarr/Readarr.  As such since I haven't really used it much, we'll just remove it.